### PR TITLE
Add reference Guide client

### DIFF
--- a/docs/userguide/event_manager.rst
+++ b/docs/userguide/event_manager.rst
@@ -1,5 +1,5 @@
-The EventManager
-================
+The EventManager server
+=======================
 
 
 The EventManager is the "server" for the MEM ecosystem.
@@ -7,76 +7,7 @@ It should be started manually by the user on the experiment control computer,
 and remain running for the duration of the session.
 
 
-.. _event-manager-launch:
+.. toctree::
 
-Launch
-------
-
-
-The EventManager service can be started by invoking it from the command-line
-with
-
-::
-
-   $ mem_server <instrument_config>
-
-where ``<instrument_config>`` should be the path to a yaml-style file that
-specifies the instrument launch options (see below).
-Additional command-line options are available to control the server tick rate,
-set the logging levels, override the default port values, etc.
-
-While running, the EventManager will print various log messages to the console
-and/or a file; the user can use these to verify that requests are being
-correctly communicated.
-
-
-Instrument config file
-----------------------
-
-
-The instrument config file, required when launching the EventManager, specifies
-the launch options for the hardware instruments (or more specifically, their
-drivers).
-It takes the following form:
-
-::
-
-   <instrument 1 nickname>:
-      <instrument 1 driver name>:
-         - <launch arg 1>
-         - <launch arg 2>
-         ...
-
-   <instrument 2 nickname>:
-      <instrument 2 driver name>:
-         - <launch arg 1>
-         - <launch arg 2>
-         ...
-
-   ...
-
-The instrument nicknames are those which will be used to refer to the
-instrument in the MEM measurement definitions.
-For example, if we are connecting to a Rohde & Schwarz ZNB Network Analyzer,
-the instrument driver (associated with the instrument server application) may
-have a name like ``rs_znb_network_analyzer``, but we can specify its nickname
-to be much simpler, like ``vna``.
-
-The launch args are typically just the instrument communication address, for
-example an IP or GPIB address, but can include other options supported by the
-instrument driver.
-Note that these are exclusively *launch* options; any instrument parameters
-that are set using key-value associations should be specified elsewhere, such
-as in the measurement definitions.
-
-The use of instrument nicknames in the measurement definitions allows us
-to decouple the conceptual elements of the measurement definition ("what we
-want to measure") from the technical details of the hardware instrument and
-its connection.
-In particular, if we move our measurement to a different experimental setup,
-say using an Agilent PNA-L instead, we need solely to change the instrument
-driver name and its launch options, while the ``vna`` nickname remains valid
-in all our measurement definitions.
-The instruments, of course, must serve the same function, and their interfaces
-must be sufficiently compatible, but it is typically clear whether or not this
-makes sense for a given set of instruments.
+   event_manager/launch
+   event_manager/operation

--- a/docs/userguide/event_manager/launch.rst
+++ b/docs/userguide/event_manager/launch.rst
@@ -1,0 +1,92 @@
+.. _event-manager-launch:
+
+Server launch
+=============
+
+
+The EventManager service can be started by invoking it from the command-line
+with
+
+::
+
+   $ mem_server <instrument_config>
+
+where ``<instrument_config>`` should be the path to a yaml-style file that
+specifies the instrument launch options (see below).
+
+When the EventManager service is running, the standard output will show a
+message and animated "spinner" to indicate its active status:
+
+::
+
+   Server active ▃▅▇
+
+When receiving requests or carrying out actions, log messages will be printed
+to the standard output and/or a log file, according to the set logging levels.
+These can be modified using the command-line options ``--console-log-level``
+and ``--file-log-level``, which accept the
+`standard Python logging level names <https://docs.python.org/3/library/logging.html#levels>`_
+or corresponding integer values.
+
+Internally, the server repeatedly polls its messaging sockets with a default
+interval of 5 seconds.
+This can be modified using the ``--tick-interval`` command-line option.
+
+All the available command-line options can be seen with
+
+::
+
+   $ mem_server --help
+
+
+
+Instrument config file
+----------------------
+
+
+The instrument config file, required when launching the EventManager, specifies
+the launch options for the hardware instruments (or more specifically, their
+drivers).
+It takes the following form:
+
+::
+
+   <instrument 1 nickname>:
+      <instrument 1 driver name>:
+         - <launch arg 1>
+         - <launch arg 2>
+         ...
+
+   <instrument 2 nickname>:
+      <instrument 2 driver name>:
+         - <launch arg 1>
+         - <launch arg 2>
+         ...
+
+   ...
+
+The instrument nicknames are those which will be used to refer to the
+instrument in the MEM measurement definitions.
+For example, if we are connecting to a Rohde & Schwarz ZNB Network Analyzer,
+the instrument driver (associated with the instrument server application) may
+have a name like ``rs_znb_network_analyzer``, but we can specify its nickname
+to be much simpler, like ``vna``.
+
+The launch args are typically just the instrument communication address, for
+example an IP or GPIB address, but can include other options supported by the
+instrument driver.
+Note that these are exclusively *launch* options; any instrument parameters
+that are set using key-value associations should be specified elsewhere, such
+as in the measurement definitions.
+
+The use of instrument nicknames in the measurement definitions allows us
+to decouple the conceptual elements of the measurement definition ("what we
+want to measure") from the technical details of the hardware instrument and
+its connection.
+In particular, if we move our measurement to a different experimental setup,
+say using an Agilent PNA-L instead, we need solely to change the instrument
+driver name and its launch options, while the ``vna`` nickname remains valid
+in all our measurement definitions.
+The instruments, of course, must serve the same function, and their interfaces
+must be sufficiently compatible, but it is typically clear whether or not this
+makes sense for a given set of instruments.

--- a/docs/userguide/event_manager/operation.rst
+++ b/docs/userguide/event_manager/operation.rst
@@ -1,0 +1,86 @@
+Server operation
+================
+
+Once started, the EventManager runs without any further direct interaction from
+the user.
+Interaction instead takes the form of **requests** sent via ZeroMQ messages
+from Guide and Controller services.
+Requests via the Guide interface are used to modify or receive information
+about the measurement queue.
+Requests via the Controller interface, initiated automatically, inform the
+EventManager about when measurements start or end.
+
+
+State variables
+---------------
+
+
+The most important data stored by the EventManager are:
+
+- The **queue** of measurement definitions to be run.
+- The **fetch counter**, an integer indicating how many measurements should be
+  run before halting.
+
+The queue is simply an ordered container for Measurement objects, allowing for
+addition and removal at arbitrary positions.
+The EventManager will always attempt to draw measurements from the front of
+the queue.
+
+.. note::
+
+   To maximize stability, queue functionality is intentionally rudimentary
+   on the server-side.
+   Advanced queue operations should be wrapped/automated via custom Guide
+   client functionality.
+
+
+It is worth distinguishing between three qualitatively different modes of
+operation based on the value of the fetch counter.
+
+- At 0, no measurements will be launched, so the user can modify the queue,
+  set up batch runs, debug and test, etc. without any time pressure.
+- At positive values, exactly that number of measurements will be launched,
+  decrementing the fetch counter each time.
+  This can be used to launch well-defined batches of measurements while
+  retaining the ability to freely modify any measurements in the queue beyond.
+- At negative values (normalized to -1), the EventManager will run in "endless"
+  mode, always attempting to launch any measurement at the front of the queue.
+
+
+.. note::
+
+   The default value of the fetch counter on EventManager service launch is 0,
+   but this can be modified via the ``--fetch-counter`` command-line option.
+
+
+Order of operations
+-------------------
+
+During each iteration of the server event loop, the following operations are
+attempted:
+
+1. Trigger a new measurement attempt
+2. Process any incoming Guide requests
+3. Process any incoming Controller requests
+
+A new measurement attempt will launch the next measurement from the queue when
+this is allowed and possible.
+In particular, this involves the following checks:
+
+- There is no measurement currently running
+- The fetch counter is not zero
+- The next measurement can be taken from the queue
+
+If these conditions are all met, the next measurement is launched via a new
+Controller process (spawned automatically by the EventManager), and the fetch
+counter is decremented.
+
+.. warning::
+
+   Once a measurement has been launched, it is assumed to be continuously
+   running until a measurement end message is received from the Controller.
+   Consequently, if the measurement freezes or fails externally to the MEM
+   services, the EventManager will be left in a soft-locked state wherein it
+   can receive and process requests, but cannot launch further measurements.
+   Currently, the only resolution is manual termination of the EventManager
+   process.

--- a/docs/userguide/measurements/definitions.rst
+++ b/docs/userguide/measurements/definitions.rst
@@ -9,13 +9,13 @@ objects.
 
 .. note::
 
-   Although the user is not required to directly interact with MeasurementParams
+   Although the user is not required to directly interact with Measurement
    objects at any point, it is helpful to understand their behaviour as they
    provide constraints on the components of a measurement definition.
 
 A measurement definition is constructured from a dict or Python mapping,
 with several top-level keys corresponding to attributes of the resulting
-MeasurementParams object.
+Measurement object.
 For user-input-based usage, it is recommended to store the measurement
 definition in a YAML file, which can be read and parsed by a Guide client.
 For programmatic usage, a ``dict`` or mapping-like object can be used directly.

--- a/docs/userguide/measurements/submit.rst
+++ b/docs/userguide/measurements/submit.rst
@@ -11,16 +11,10 @@ The rules of the messaging protocol dictate what requests are possible,
 although a Guide client is free to provide whatever interface to these requests
 best suits the user.
 
-The following examples show the process using
-`samsguideclient <https://github.com/SamWolski/samsguideclient/>`_
-which will be integrated into the MEM distribution in the near future.
-The package provides both a scripting API and an interactive command-line
-interface.
-
-.. note::
-
-   Currently, the examples in this section require the ``samsguideclient``
-   package.
+The following examples show the process using the provided
+:doc:`rgc </autoapi/measurement_event_manager/rgc/index>`
+Guide client.
+It provides both a scripting API and an interactive command-line interface.
 
 
 Interactive command-line interface
@@ -30,9 +24,9 @@ The interactive command-line interface can be invoked from a terminal using
 
 ::
 
-   $ sgc -i
+   $ rgc -i
 
-The following commands are available in the sgc shell:
+The following commands are available in the rgc shell:
 
 - ``add <measurement_path> [<measurement_path_2> ...]`` submits the
   measurement definitions loaded from the files at the various locations
@@ -44,12 +38,14 @@ The following commands are available in the sgc shell:
   Multiple index specifications will be parsed *before* any deletions are
   carried out, so ``remove 0 3`` will not unintentionally remove the
   item at index 4 (which would be at index 3 once index 0 is removed).
-- ``query [<target>]`` fetches the current state of the queue, i.e. all the
-  measurement definitions that currently make up the queue.
+- ``query [<target>]`` or ``queue [<target>]`` fetches the current state of
+  the queue, i.e. all the measurement definitions that currently make up the
+  queue.
   These are written to the ``target`` (a file-like object), or if no target is
   provided, printed to the standard output.
 - ``len`` fetches the current length of the queue (the number of measurements).
-- ``fetch [<counter_value>]`` interacts with the fetch counter.
+- ``fetch [<counter_value>]`` or ``counter [<counter_value>]`` interacts with
+  the fetch counter.
   If no argument is provided, it gets the current value.
   If an argument is provided, in this case a single integer, the fetch counter
   will be set to this value.

--- a/docs/userguide/services.rst
+++ b/docs/userguide/services.rst
@@ -41,18 +41,28 @@ In brief, the control flow for an experimental session is:
    In principle, the other services can be run on the experiment control
    computer or communicate over a network, as desired.
 
-This package provides the core
-:doc:`EventManager </autoapi/measurement_event_manager/event_manager/EventManager>`
+This package provides the following:
+
+- The core
+  :doc:`EventManager </autoapi/measurement_event_manager/event_manager/EventManager>`
+  service.
+- A
+  :doc:`Controller </autoapi/measurement_event_manager/controller/Controller>`
+  service for pyHegel (an open-source instrument server application used at the
+  IQ at the Université de Sherbrooke).
+- A reference implementation of a Guide client service, the 
+  :doc:`rgc </autoapi/measurement_event_manager/rgc/index>`
+  (reference guide client).
+
+This project is licensed under the LGPLv3, meaning that any of these components
+can be modified (in keeping with the license conditions) or replaced by the
+user.
+For example,
+a custom Controller service can be used to interface with a different
+instrument server such as Labber,
 and
-:doc:`Controller </autoapi/measurement_event_manager/controller/Controller>`
-services.
-
-Here are some publicly-available Guide clients:
-
-- `samsguideclient <https://github.com/SamWolski/samsguideclient/>`_
-
-In case none of the Guide client applications suit your needs, you can write
-your own!
-You can use any language supporting `ZeroMQ <https://zeromq.org>`_, and your
-application should conform to the appropriate version of the MEM Client
-protocol.
+a custom Guide can be used to define measurement parameters using a GUI or
+reading from a different file format.
+Custom components can be written in any language supporting
+`ZeroMQ <https://zeromq.org>`_, and should conform to the appropriate version
+of the MEM Client protocol.

--- a/measurement_event_manager/cmdline/mem_server.py
+++ b/measurement_event_manager/cmdline/mem_server.py
@@ -156,7 +156,7 @@ def main() -> None:
 	## Guide reply socket
 	guide_reply_socket = context.socket(zmq.REP)
 	guide_reply_socket.bind(guide_reply_endpoint)
-	logger.debug('Guide reply socket bound to {}'.format(guide_reply_endpoint))
+	logger.debug('Guide reply socket bound to %s', guide_reply_endpoint)
 
 	## Controller reply address
 	if cmd_args.meas_port is not None:
@@ -167,9 +167,7 @@ def main() -> None:
 	## Controller reply socket
 	ctrl_reply_socket = context.socket(zmq.REP)
 	ctrl_reply_socket.bind(ctrl_reply_endpoint)
-	logger.debug(
-		'Controller reply socket bound to {}'.format(ctrl_reply_endpoint)
-	)
+	logger.debug('Controller reply socket bound to %s', ctrl_reply_endpoint)
 
 	## Controller request address
 	## Passed to the instatiation function for the spawned Controller process
@@ -184,9 +182,7 @@ def main() -> None:
 	## Listener broadcast socket
 	listener_pub_socket = context.socket(zmq.PUB)
 	listener_pub_socket.bind(listener_pub_endpoint)
-	logger.debug(
-		'Listener pub socket bound to {}'.format(listener_pub_endpoint)
-	)
+	logger.debug('Listener pub socket bound to %s', listener_pub_endpoint)
 
 
 	## Set up poller for main event loop

--- a/measurement_event_manager/cmdline/mem_server.py
+++ b/measurement_event_manager/cmdline/mem_server.py
@@ -231,7 +231,7 @@ def main() -> None:
 	logger.info('Running main event loop.')
 
 	spinner_kwargs = {
-		"title": "Server listening",
+		"title": "Server active",
 		"bar": False,
 		"enrich_print": False,
 		"monitor": False,

--- a/measurement_event_manager/cmdline/rgc.py
+++ b/measurement_event_manager/cmdline/rgc.py
@@ -1,0 +1,126 @@
+"""
+Command-line invocation of the Reference Guide Client (rgc)
+
+The rgc is a fully-functional example implementation of a Guide service and
+interface bundled with the main MEM package.
+
+See :doc:`rgc </autoapi/measurement_event_manager/rgc/index>` for more
+information about the client class and interactive shell-style interface.
+"""
+
+import argparse
+import logging
+import os
+
+import zmq
+
+from .._const import DEF_PROTOCOL, DEF_GUIDE_PORT
+from ..rgc import ReferenceGuideClient, GuideClientShell
+from ..util import log as mem_logging
+
+
+###############################################################################
+
+
+def main():
+	"""Start the Reference Guide Client
+	"""
+
+	## Parse command-line arguments
+	###############################
+
+	parser = argparse.ArgumentParser()
+
+	parser.add_argument(
+		"config",
+		help="Config file(s) containing measurement parameters",
+		nargs="*",
+	)
+
+	parser.add_argument(
+		"--endpoint",
+		help="Endpoint address for MEM server connection",
+		default=None,
+	)
+
+	parser.add_argument(
+		"--interactive", "-i",
+		help="Enable interactive mode",
+		action="store_true",
+	)
+
+	parser.add_argument(
+		"--console-log-level",
+		help="Logging level for console output",
+		default="info",
+	)
+
+	parser.add_argument(
+		"--file-log-level",
+		help="Logging level for file output",
+		default="info",
+	)
+
+	cmd_args = parser.parse_args()
+
+
+	## Logging
+	##########
+
+
+	logger = mem_logging.quick_config(
+		logging.getLogger("ReferenceGuideClient"),
+		console_log_level=mem_logging.parse_log_level(
+			cmd_args.console_log_level,
+		),
+		file_log_level=mem_logging.parse_log_level(
+			cmd_args.file_log_level
+		),
+	)
+
+
+	## Communications setup
+	#######################
+
+
+	## Initialize context
+	context = zmq.Context()
+
+	## Guide request endpoint
+	if cmd_args.endpoint is not None:
+		guide_endpoint = cmd_args.endpoint
+	else:
+		guide_endpoint = f"{DEF_PROTOCOL}://localhost:{DEF_GUIDE_PORT}"
+
+
+	## Guide client
+	###############
+
+
+	## Instantiate Guide client class
+	guide_client = ReferenceGuideClient(
+		endpoint=guide_endpoint,
+		logger=logger,
+		zmq_context=context,
+	)
+
+
+	## Process args
+	###############
+
+
+	## Add specified config(s)
+	for config_file in cmd_args.config:
+		guide_client.add_from_file(os.getcwd(), config_file)
+
+
+	## Interactive mode
+	###################
+
+
+	if cmd_args.interactive:
+		GuideClientShell(guide_client).cmdloop()
+
+
+if __name__ == '__main__':
+	main()

--- a/measurement_event_manager/cmdline/rgc.py
+++ b/measurement_event_manager/cmdline/rgc.py
@@ -119,6 +119,15 @@ def main():
 
 
 	if cmd_args.interactive:
+
+		## Remove the console handler
+		## TODO currently this is sufficient, as the console handler will
+		## always exist in this context. However, the way logging is handled
+		## should probably be changed, which will make it possible to carry
+		## out operations like this more robustly.
+		logger.removeHandler(logger.handlers[0])
+
+		## Launch shell
 		GuideClientShell(guide_client).cmdloop()
 
 

--- a/measurement_event_manager/event_manager.py
+++ b/measurement_event_manager/event_manager.py
@@ -141,8 +141,10 @@ class EventManager:
         ## If the fetch counter is at 0, we cannot attempt to start a new
         ## measurement
         elif self._fetch_counter == 0:
-            self.logger.debug('Fetch counter is at 0; skipping fetch and'
-                             ' waiting for increase')
+            self.logger.debug(
+                'Fetch counter is at 0; skipping fetch and waiting for '
+                'increase...'
+            )
             return False
 
         ## We are allowed to fetch a new measurement
@@ -161,8 +163,10 @@ class EventManager:
 
         ## Actual subprocess launch can be disabled for debugging
         if disable_launch:
-            self.logger.warning('Launch disabled; measurement thread is '
-                                'expected to be started manually.')
+            self.logger.warning(
+                'Launch disabled; measurement thread is expected to be '
+                'started manually.'
+            )
         else:
             self.logger.info('Launching measurement...')
             ## Identify the OS as creating a detached process is handled
@@ -308,8 +312,9 @@ class EventManager:
         ## specific to avoid weird behaviour
         if self._fetch_counter > 0:
             self._fetch_counter -= 1
-            self.logger.info('Fetch counter decremented to '
-                             '{}'.format(self._fetch_counter))
+            self.logger.info(
+                'Fetch counter decremented to %d', self._fetch_counter
+            )
         elif self._fetch_counter == 0:
             raise ValueError("Fetch counter is at 0; cannot be decremented")
         else:

--- a/measurement_event_manager/rgc/__init__.py
+++ b/measurement_event_manager/rgc/__init__.py
@@ -24,3 +24,4 @@ The interfaces are instead the objects whose APIs should be conformed to.
 """
 
 from .rgc import ReferenceGuideClient
+from .rgcsh import GuideClientShell

--- a/measurement_event_manager/rgc/__init__.py
+++ b/measurement_event_manager/rgc/__init__.py
@@ -1,0 +1,26 @@
+"""
+This module provides a reference implementation of a Guide client application
+with various user interface paradigms.
+
+The Guide application is the intended means of user interaction with the MEM
+ecosystem.
+In particular, the Guide application translates the user's commands, be they
+specified in a script, an interactive shell, or otherwise, into MEM requests
+transmitted to the server.
+A sophisticated Guide application can also relay the server's responses back
+to the user, and while this is highly recommended, it is strictly speaking not
+required.
+
+The core of this reference implementation is the ReferenceGuideClient class.
+This class can be instantiated and used directly in a script or interactive
+Python interpreter. 
+This provides an API-style access to typical Guide service features in a more
+user-friendly way than interacting with a GuideRequestInterface object
+directly.
+
+The classes provided here are *not* intended as bases which all user-extended
+classes must inherit from (although of course the user is welcome to do so).
+The interfaces are instead the objects whose APIs should be conformed to.
+"""
+
+from .rgc import ReferenceGuideClient

--- a/measurement_event_manager/rgc/rgc.py
+++ b/measurement_event_manager/rgc/rgc.py
@@ -226,6 +226,10 @@ class ReferenceGuideClient:
 			sys.stdout.writelines(print_generator)
 
 
+	## Defining the fetch counter using the property decorator is extremely
+	## convenient, but has the disadvantage that we cannot easily see what the
+	## confirmed value from the server is outside of the log messages (as the
+	## setter has no return). As such, this structure may change in the future.
 	@property
 	def fetch_counter(self) -> int:
 		"""Server queue fetch counter value
@@ -235,7 +239,6 @@ class ReferenceGuideClient:
 		return counter
 
 	@fetch_counter.setter
-	def fetch_counter(self, new_value: int) -> int:
+	def fetch_counter(self, new_value: int):
 		counter = self._interface.set_counter(new_value)
-		self.logger.info(f"Fetch counter set to {counter}")
-		return counter
+		self.logger.info("Fetch counter set to %s", counter)

--- a/measurement_event_manager/rgc/rgc.py
+++ b/measurement_event_manager/rgc/rgc.py
@@ -1,0 +1,241 @@
+"""
+The reference implementation of a Guide client
+"""
+
+from collections.abc import Iterable, Mapping, Sequence
+import logging
+import os
+import sys
+from typing import Optional
+
+import himl
+import zmq
+
+from ..interfaces.guide import GuideRequestInterface
+from ..measurement import Measurement
+from ..util import log as mem_logging
+
+
+###############################################################################
+## Helper functions
+###############################################################################
+
+
+def load_config(base_dir: str, config_path: str) -> dict:
+	"""Load a himl config via the config_path based on the base_dir
+	"""
+
+	cfg = himl.ConfigProcessor().process(
+		cwd=base_dir,
+		path=os.path.join(base_dir, config_path),
+		type_strategies=[
+			(list, ["override"]), (dict, ["merge"]),
+		],
+	)
+
+	return cfg
+
+
+###############################################################################
+## Guide client class
+###############################################################################
+
+
+class ReferenceGuideClient:
+	"""A reference implementation of a MEM Guide client class
+
+	Note that this is *not* a base class which all Guide clients must inherit
+	from, but rather an example of a generic implementation which interoperates
+	with the appropriate interface.
+	"""
+
+
+	def __init__(self,
+		endpoint: str,
+		logger: Optional[logging.Logger] = None,
+		zmq_context: Optional[zmq.Context] = None,
+		):
+
+		## Logging
+		if logger is None:
+			logger = logging.getLogger(__name__)
+			self.logger = mem_logging.quick_config(
+				logger,
+				console_log_level=logging.INFO,
+				file_log_level=None,
+			)
+		else:
+			self.logger = logger
+
+		## ZMQ messaging
+		self._endpoint = endpoint
+		if zmq_context is None:
+			self._context = zmq.Context()
+		else:
+			self._context = zmq_context
+
+		## Interface initialization
+		## Start with empty socket - will be added when connecting
+		self._interface = GuideRequestInterface(
+			socket=None,
+			protocol_name="MEM-GR/0.1",
+			logger=self.logger,
+		)
+
+		## Set up connection
+		## Automatic the first time; reconnects must be manual
+		self.connect_to_server()
+
+
+	## Server communication
+	#######################
+
+
+	def connect_to_server(self,
+		endpoint: Optional[str] = None,
+		) -> None:
+		"""Connect to a server
+
+		Updates the stored endpoint if one is provided as an arg.
+		"""
+
+		## Update the stored endpoint if a new one is specified
+		if endpoint is not None:
+			self._endpoint = endpoint
+
+		## (Re)open the socket
+		guide_request_socket = self._context.socket(zmq.REQ)
+		guide_request_socket.connect(self._endpoint)
+		self.logger.debug(f"Guide request socket bound to {self._endpoint}")
+		## Update the socket at the interface
+		self._interface.set_socket(guide_request_socket)
+
+
+	## Add measurements
+	###################
+
+
+	def add_from_file(self,
+		base_dir: str,
+		config_path: str,
+		) -> None:
+		"""Add a measurement defined by a himl config hierarchy
+		"""
+
+		## Load config using himl consolidation
+		self.logger.debug(f"Loading from file: {config_path}")
+		self.logger.debug(f"himl base_dir is {base_dir}")
+		config = load_config(base_dir, config_path)
+		## Add the measurement based on the loaded config
+		self.add_from_dict(config)
+
+
+	def add_from_dict(self, params_dict: Mapping) -> None:
+		"""Add a measurement defined by a dict or mapping
+		"""
+
+		## Creating a Measurement object acts as a validity check on the
+		## client side.
+		self.logger.debug("Creating Measurement object...")
+		measurement = Measurement(**params_dict)
+
+		## Add the Measurement via the interface API
+		self.logger.debug("Sending Measurement to server...")
+		self._interface.add(measurement)
+
+
+	## Remove measurements
+	######################
+
+
+	def remove(self, index_iterable: Iterable) -> list[int]:
+		"""Remove measurements from the queue by index
+		"""
+
+		## Generate available queue indices
+		if (queue_length := self.queue_length) == 0:
+			self.logger.warning("Measurement queue is empty; cannot remove.")
+			return []
+		queue_indices = list(range(queue_length))
+
+		## Apply each index specification directly to the available index list
+		## to allow for full use of Python indexing constructs like slices
+		resolved_indices = []
+		for index_spec in index_iterable:
+			target_indices = queue_indices[index_spec]
+			## Check if target indices are a singleton or list to avoid nested
+			## list elements
+			if isinstance(target_indices, Sequence):
+				resolved_indices.extend(target_indices)
+			else:
+				resolved_indices.append(target_indices)
+
+		## De-dupe resolved indices via set
+		index_list = list(set(resolved_indices))
+
+		## Send the removal request
+		removed_indices = self._interface.remove(index_list)
+
+		## Return the indices that were actually removed according to the
+		## server
+		self.logger.info(f"Successfully removed indices {removed_indices}")
+		return removed_indices
+
+
+	## Queue status
+	###############
+
+
+	@property
+	def queue_length(self) -> int:
+		"""Current queue length
+		"""
+		return self._interface.len()
+
+
+	@property
+	def queue(self) -> list[Measurement]:
+		"""Current contents of the server queue
+		"""
+
+		queue = self._interface.query()
+		return queue
+
+
+	def dump_queue_contents(self, target: Optional[str] = None) -> None:
+		"""Dump the contents of the server queue to a writable target
+		"""
+
+		## Iterate over measurements and get pretty print representation
+		print_list = []
+		for index, meas in enumerate(self.queue):
+			## Get pretty representation
+			pretty_str = meas.pretty_print()
+			## Add header and footer
+			pretty_header = f"== Index {index: <4}" + "="*46 + "\n"
+			pretty_footer = "="*59 + "\n"
+			print_list.append(pretty_header + pretty_str + pretty_footer)
+
+		print_generator = (f"{pp}\n" for pp in print_list)
+		## Write to file-like object
+		if target:
+			with open(target, 'w') as target_handle:
+				target_handle.writelines(print_generator)
+		## Fall back on stdout
+		else:
+			sys.stdout.writelines(print_generator)
+
+
+	@property
+	def fetch_counter(self) -> int:
+		"""Server queue fetch counter value
+		"""
+		counter = self._interface.get_counter()
+		self.logger.info(f"Fetch counter is {counter}")
+		return counter
+
+	@fetch_counter.setter
+	def fetch_counter(self, new_value: int) -> int:
+		counter = self._interface.set_counter(new_value)
+		self.logger.info(f"Fetch counter set to {counter}")
+		return counter

--- a/measurement_event_manager/rgc/rgc.py
+++ b/measurement_event_manager/rgc/rgc.py
@@ -106,7 +106,7 @@ class ReferenceGuideClient:
 		## (Re)open the socket
 		guide_request_socket = self._context.socket(zmq.REQ)
 		guide_request_socket.connect(self._endpoint)
-		self.logger.debug(f"Guide request socket bound to {self._endpoint}")
+		self.logger.debug("Guide request socket bound to %s", self._endpoint)
 		## Update the socket at the interface
 		self._interface.set_socket(guide_request_socket)
 
@@ -123,8 +123,8 @@ class ReferenceGuideClient:
 		"""
 
 		## Load config using himl consolidation
-		self.logger.debug(f"Loading from file: {config_path}")
-		self.logger.debug(f"himl base_dir is {base_dir}")
+		self.logger.info("Loading from file %s", config_path)
+		self.logger.debug("himl base_dir is %s", base_dir)
 		config = load_config(base_dir, config_path)
 		## Add the measurement based on the loaded config
 		self.add_from_dict(config)
@@ -178,7 +178,7 @@ class ReferenceGuideClient:
 
 		## Return the indices that were actually removed according to the
 		## server
-		self.logger.info(f"Successfully removed indices {removed_indices}")
+		self.logger.info("Successfully removed indices %s", removed_indices)
 		return removed_indices
 
 
@@ -235,7 +235,7 @@ class ReferenceGuideClient:
 		"""Server queue fetch counter value
 		"""
 		counter = self._interface.get_counter()
-		self.logger.info(f"Fetch counter is {counter}")
+		self.logger.info("Fetch counter is %s", counter)
 		return counter
 
 	@fetch_counter.setter

--- a/measurement_event_manager/rgc/rgcsh.py
+++ b/measurement_event_manager/rgc/rgcsh.py
@@ -1,0 +1,237 @@
+"""
+Interactive shell for the reference Guide client implementation
+"""
+
+import cmd
+import os
+
+from ..util.errors import ConnectionTimeoutError
+from .rgc import ReferenceGuideClient
+
+
+###############################################################################
+## Helper functions
+###############################################################################
+
+
+def parse_index_int(index_str: str) -> int:
+	"""Parse a string representing a numeric index, which may be empty
+	"""
+	## If the string is empty (eg when using open-ended slices), return None
+	## for valid slice construction
+	if index_str == "":
+		return None
+	return int(index_str)
+
+
+###############################################################################
+## GuideClientShell
+###############################################################################
+
+
+class GuideClientShell(cmd.Cmd):
+	"""An interactive shell interface for a MEM Guide Client
+	"""
+
+	## Class attributes from the example in the Python docs
+	intro = "MEM Guide client interactive mode."
+	prompt = "[rgc] "
+	file = None
+
+
+	def __init__(self,
+		guide_client: ReferenceGuideClient,
+		*args, **kwargs,
+		):
+		self.guide_client = guide_client
+		super().__init__(*args, **kwargs)
+
+
+	## Cmd method overrides
+	#######################
+
+
+	def emptyline(self):
+		## Do nothing when an empty line is returned, instead of the default
+		## behaviour which is to repeat the last command.
+		pass
+
+
+	## Here, we override onecmd() in order to wrap any executed command
+	## in a try-catch block looking for a ConnectionTimeoutError.
+	## This way, we don't have to clutter up the code for each individual
+	## command definition, and commands that have nothing to do with sending
+	## requests to the server will not be affected anyway.
+	## pylint: disable-next=inconsistent-return-statements
+	def onecmd(self, line):
+		"""Interpret the argument as though it had been typed in response
+		to the prompt.
+
+		This may be overridden, but should not normally need to be;
+		see the precmd() and postcmd() methods for useful execution hooks.
+		The return value is a flag indicating whether interpretation of
+		commands by the interpreter should stop.
+		"""
+
+		## Up until the next comment is the same as the original
+		## pylint: disable-next=redefined-outer-name
+		cmd, arg, line = self.parseline(line)
+		if not line:
+			return self.emptyline()
+		if cmd is None:
+			return self.default(line)
+		self.lastcmd = line
+		if line == 'EOF' :
+			self.lastcmd = ''
+		if cmd == '':
+			return self.default(line)
+		else:
+			try:
+				func = getattr(self, 'do_' + cmd)
+			except AttributeError:
+				return self.default(line)
+			## Attempt to execute the command with custom exception handling
+			try:
+				result = func(arg)
+			except ConnectionTimeoutError:
+				print("*** Connection timed out; command incomplete. ***")
+			else:
+				return result
+
+
+	## Server interactions
+	######################
+
+
+	def do_connect(self, endpoint):
+		"""Connect to the specified endpoint
+		"""
+
+		## TODO perhaps find a more elegant way of handling empty strings
+		## Currently, we need to make sure that an empty string (the result of
+		## not writing an explicit value in the shell) is passed on to the
+		## connection method as None, indicating that the stored endpoint
+		## should be used.
+		endpoint = endpoint if endpoint else None
+		self.guide_client.connect_to_server(endpoint=endpoint)
+
+
+	def do_fetch(self, new_value):
+		"""Interact with the fetch counter of the server queue
+
+		A single int argument will be used to set the value.
+		Calling with no arguments will query the existing value.
+		"""
+
+		try:
+			new_value = int(new_value)
+		except ValueError:
+			print(f"Fetch counter is at {self.guide_client.fetch_counter}")
+		else:
+			self.guide_client.fetch_counter = new_value
+			print(f"Fetch counter set to {self.guide_client.fetch_counter}")
+
+
+	## Messaging and requests
+	#########################
+
+
+	def do_add(self, config_path):
+		"""Add a measurement to the queue using the specified config file(s)
+		"""
+		try:
+			self.guide_client.add_from_file(
+				base_dir=os.getcwd(),
+				config_path=config_path,
+			)
+		except FileNotFoundError:
+			print(
+				f"Config file not found at {config_path}; cannot process add "
+				"request."
+			)
+
+
+	def do_remove(self, index_string):
+		"""Remove a measurement from the queue
+
+		Python's slicing syntax is supported using the : delimiter, eg 2:5
+		"""
+
+		## Default to removing the last element
+		if index_string == "":
+			index_string = "-1"
+		index_list = index_string.split(" ")
+		index_spec = []
+
+		## Parse different items supplied
+		for index_str in index_list:
+
+			## Ranges using : syntax
+			if index_str.count(":") == 2:
+				start, stop, step = index_str.split(":")
+				## We must be able to parse *all* of the components for the
+				## slice to work, so it's okay to put everything inside the
+				## same try block
+				try:
+					new_slice = slice(
+						parse_index_int(start),
+						parse_index_int(stop),
+						parse_index_int(step),
+					)
+				except ValueError:
+					print(f"Index f{index_str} cannot be parsed")
+					continue
+				else:
+					index_spec.append(new_slice)
+
+			elif index_str.count(":") == 1:
+				start, stop = index_str.split(":")
+				## Same as above
+				try:
+					new_slice = slice(
+						parse_index_int(start),
+						parse_index_int(stop),
+					)
+				except ValueError:
+					print(f"Index f{index_str} cannot be parsed")
+					continue
+				else:
+					index_spec.append(new_slice)
+
+			## Single scalar values
+			else:
+				try:
+					new_index = int(index_str)
+				except ValueError:
+					print(f"Index f{index_str} cannot be parsed")
+					continue
+				else:
+					index_spec.append(new_index)
+
+		## API call with parsed values (ie *not* strings!)
+		self.guide_client.remove(index_spec)
+
+
+	def do_query(self, target):
+		"""Query the queue contents and dump them to a writeable target
+
+		Defaults to sys.stdout
+		"""
+		self.guide_client.dump_queue_contents(target)
+
+
+	## pylint: disable-next=unused-argument
+	def do_len(self, args):
+		"""Query the length of the server queue
+		"""
+		print(self.guide_client.queue_length)
+
+
+	## Shell functionality
+	######################
+
+
+	## pylint: disable-next=unused-argument
+	def do_exit(self, args):
+		return True
+

--- a/measurement_event_manager/rgc/rgcsh.py
+++ b/measurement_event_manager/rgc/rgcsh.py
@@ -123,13 +123,16 @@ class GuideClientShell(cmd.Cmd):
 		Calling with no arguments will query the existing value.
 		"""
 
+		## Set/get the fetch counter
 		try:
 			new_value = int(new_value)
 		except ValueError:
-			print(f"Fetch counter is at {self.guide_client.fetch_counter}")
+			pass
 		else:
 			self.guide_client.fetch_counter = new_value
-			print(f"Fetch counter set to {self.guide_client.fetch_counter}")
+
+		## Informational messages
+		print(f"Fetch counter is {self.guide_client.fetch_counter}")
 
 
 	## Messaging and requests

--- a/measurement_event_manager/rgc/rgcsh.py
+++ b/measurement_event_manager/rgc/rgcsh.py
@@ -135,6 +135,12 @@ class GuideClientShell(cmd.Cmd):
 		print(f"Fetch counter is {self.guide_client.fetch_counter}")
 
 
+	def do_counter(self, new_value):
+		"""Alias for `fetch`
+		"""
+		self.do_fetch(new_value)
+
+
 	## Messaging and requests
 	#########################
 
@@ -222,6 +228,12 @@ class GuideClientShell(cmd.Cmd):
 		Defaults to sys.stdout
 		"""
 		self.guide_client.dump_queue_contents(target)
+
+
+	def do_queue(self, target):
+		"""Alias for `query`
+		"""
+		self.do_query(target)
 
 
 	## pylint: disable-next=unused-argument

--- a/measurement_event_manager/rgc/rgcsh.py
+++ b/measurement_event_manager/rgc/rgcsh.py
@@ -212,7 +212,8 @@ class GuideClientShell(cmd.Cmd):
 					index_spec.append(new_index)
 
 		## API call with parsed values (ie *not* strings!)
-		self.guide_client.remove(index_spec)
+		removed_indices = self.guide_client.remove(index_spec)
+		print(f'Removed indices: {removed_indices}')
 
 
 	def do_query(self, target):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ dependencies = [
 [project.scripts]
 mem_server = "measurement_event_manager.cmdline.mem_server:main"
 mem_launch_measurement = "measurement_event_manager.cmdline.mem_launch_measurement:main"
+rgc = "measurement_event_manager.cmdline.rgc:main"
 
 [project.urls]
 Homepage = "https://github.com/M1-QuantumLab/MeasurementEventManager"


### PR DESCRIPTION
Integrate a reference implementation of a Guide client into the package.

The package is now fully contained, in the sense that no additional packages are required to actually run the MEM ecosystem.
Additionally, the reference implementation serves as an example for custom Guide clients.